### PR TITLE
Add level rendering logic

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,3 +13,32 @@ This project is intended as a simple starting point for expanding into a full pu
 ## Getting Started
 
 Open `index.html` in a modern browser to try the demo. No build step or external dependencies are required.
+
+## Level Configuration
+
+Levels are defined in `levels.json`. The file contains a JSON array where each
+element describes one level. A level is made of rows, each containing a list of
+cells. Every cell specifies a `baseHeight` integer and a list of `objects` which
+are just color strings. For example:
+
+```json
+{
+  "rows": [
+    [
+      { "baseHeight": 1, "objects": ["green"] },
+      { "baseHeight": 0, "objects": [] }
+    ]
+  ]
+}
+```
+
+The game script loads this configuration on startup so new levels can be added
+without modifying the JavaScript.
+
+## Level Rendering
+
+Each base is drawn using an image named `img/base_{baseHeight}.png` and each
+object uses `img/object_{name}.png`. The canvas reserves 5% of the screen on the
+sides and 15% at the bottom. Bases are positioned in a grid with 20% of the base
+width separating cells horizontally and 50% of the base width separating rows
+vertically. Everything is scaled uniformly to fit the available space.

--- a/index.html
+++ b/index.html
@@ -13,6 +13,7 @@
     </div>
 
     <div id="game-screen" class="screen">
+        <canvas id="game-canvas"></canvas>
         <h1 id="game-title">Game Screen - Level 1</h1>
         <button id="complete-button">Complete Level</button>
     </div>

--- a/levels.json
+++ b/levels.json
@@ -1,0 +1,26 @@
+[
+  {
+    "rows": [
+      [
+        { "baseHeight": 1, "objects": ["green"] },
+        { "baseHeight": 0, "objects": [] }
+      ],
+      [
+        { "baseHeight": 2, "objects": ["red", "blue"] },
+        { "baseHeight": 1, "objects": ["yellow"] }
+      ]
+    ]
+  },
+  {
+    "rows": [
+      [
+        { "baseHeight": 0, "objects": [] },
+        { "baseHeight": 2, "objects": ["blue", "blue"] }
+      ],
+      [
+        { "baseHeight": 1, "objects": ["red"] },
+        { "baseHeight": 3, "objects": ["yellow", "green", "green"] }
+      ]
+    ]
+  }
+]

--- a/script.js
+++ b/script.js
@@ -1,4 +1,152 @@
 let currentLevel = 1;
+let levelConfigs = [];
+const baseImages = {};
+const objectImages = {};
+const bases = [];
+const canvas = document.getElementById('game-canvas');
+const ctx = canvas.getContext('2d');
+
+/**
+ * Helper to load an image and return a promise that resolves
+ * with the Image object when it is ready for drawing.
+ */
+function loadImage(src) {
+    return new Promise((resolve, reject) => {
+        const img = new Image();
+        img.onload = () => resolve(img);
+        img.onerror = reject;
+        img.src = src;
+    });
+}
+
+/**
+ * Represents a single base platform. It stores the base height,
+ * the objects placed on it and the calculated drawing rectangle.
+ * Position and size are assigned during layout.
+ */
+class Base {
+    constructor(baseHeight, objects) {
+        this.baseHeight = baseHeight;
+        this.objects = objects;
+        this.x = 0;
+        this.y = 0;
+        this.w = 0;
+        this.h = 0;
+    }
+
+    setRect(x, y, w, h) {
+        this.x = x;
+        this.y = y;
+        this.w = w;
+        this.h = h;
+    }
+
+    draw() {
+        const img = baseImages[this.baseHeight];
+        ctx.drawImage(img, this.x, this.y, this.w, this.h);
+        const objSize = this.w * 0.8;
+        let currentY = this.y - objSize;
+        for (const name of this.objects) {
+            const objImg = objectImages[name];
+            const objX = this.x + (this.w - objSize) / 2;
+            ctx.drawImage(objImg, objX, currentY, objSize, objSize);
+            currentY -= objSize;
+        }
+    }
+}
+
+/**
+ * Calculate layout for a level and preload all required images.
+ * The algorithm gathers unique base heights and object colors,
+ * loads their images if needed and then positions each base in
+ * a grid. Horizontal spacing is 20% of base width and vertical
+ * spacing is 50% of base width. The entire level is scaled to fit
+ * within the canvas while keeping a 5% margin on the sides and a
+ * 15% margin at the bottom.
+ */
+async function prepareLevel(level) {
+    bases.length = 0;
+    const neededBases = new Set();
+    const neededObjects = new Set();
+    level.rows.forEach(row => row.forEach(cell => {
+        neededBases.add(cell.baseHeight);
+        cell.objects.forEach(o => neededObjects.add(o));
+    }));
+
+    await Promise.all([...neededBases].map(h => {
+        if (baseImages[h]) return Promise.resolve();
+        return loadImage(`img/base_${h}.png`).then(img => { baseImages[h] = img; });
+    }));
+    await Promise.all([...neededObjects].map(o => {
+        if (objectImages[o]) return Promise.resolve();
+        return loadImage(`img/object_${o}.png`).then(img => { objectImages[o] = img; });
+    }));
+
+    const sampleBase = baseImages[[...neededBases][0]];
+    const baseW = sampleBase.width;
+    const baseH = sampleBase.height;
+    const hGap = baseW * 0.2;
+    const vGap = baseW * 0.5;
+
+    const rows = level.rows;
+    const rowCount = rows.length;
+    const maxCells = Math.max(...rows.map(r => r.length));
+
+    const unscaledW = maxCells * baseW + (maxCells - 1) * hGap;
+    const unscaledH = rowCount * baseH + (rowCount - 1) * vGap;
+
+    const cw = canvas.width = canvas.clientWidth;
+    const ch = canvas.height = canvas.clientHeight;
+    const areaW = cw * 0.9;
+    const areaH = ch * 0.85;
+    const scale = Math.min(areaW / unscaledW, areaH / unscaledH);
+
+    const startX = cw * 0.05 + (areaW - unscaledW * scale) / 2;
+    const startY = (areaH - unscaledH * scale) / 2;
+
+    rows.forEach((row, ri) => {
+        row.forEach((cell, ci) => {
+            const b = new Base(cell.baseHeight, cell.objects);
+            const x = startX + ci * (baseW + hGap) * scale;
+            const y = startY + ri * (baseH + vGap) * scale;
+            b.setRect(x, y, baseW * scale, baseH * scale);
+            bases.push(b);
+        });
+    });
+}
+
+function drawLevel() {
+    ctx.clearRect(0, 0, canvas.width, canvas.height);
+    bases.forEach(b => b.draw());
+}
+
+/**
+ * Load level configuration from an external JSON file.
+ * The JSON contains an array of level objects. Each level
+ * describes rows of cells where a cell has a base height and
+ * a list of game objects. Once loaded the first level is shown.
+ */
+async function loadLevelConfigs() {
+    try {
+        const response = await fetch('levels.json');
+        levelConfigs = await response.json();
+        showLevel(currentLevel);
+    } catch (err) {
+        console.error('Failed to load level configuration', err);
+    }
+}
+
+/**
+ * Update the game screen for the provided level number. This demo
+ * only sets the title but real rendering would use the level data.
+ */
+async function showLevel(number) {
+    document.getElementById('game-title').textContent = `Game Screen - Level ${number}`;
+    const level = levelConfigs[number - 1];
+    if (!level) return;
+    await prepareLevel(level);
+    drawLevel();
+}
 
 const screens = {
     start: document.getElementById('start-screen'),
@@ -13,6 +161,7 @@ function showScreen(name) {
 
 document.getElementById('start-button').addEventListener('click', () => {
     showScreen('game');
+    showLevel(currentLevel);
 });
 
 document.getElementById('complete-button').addEventListener('click', () => {
@@ -22,7 +171,10 @@ document.getElementById('complete-button').addEventListener('click', () => {
 
 document.getElementById('next-button').addEventListener('click', () => {
     currentLevel += 1;
-    document.getElementById('game-title').textContent = `Game Screen - Level ${currentLevel}`;
+    showLevel(currentLevel);
     showScreen('game');
 });
+
+// Kick off loading of the configuration when the script loads.
+loadLevelConfigs();
 

--- a/style.css
+++ b/style.css
@@ -16,6 +16,7 @@ html, body {
     justify-content: center;
     align-items: center;
     flex-direction: column;
+    position: relative;
 }
 .screen.active {
     display: flex;
@@ -24,5 +25,14 @@ button {
     margin-top: 20px;
     padding: 10px 20px;
     font-size: 18px;
+}
+
+#game-canvas {
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    pointer-events: none;
 }
 


### PR DESCRIPTION
## Summary
- add canvas for level drawing
- calculate base positions and draw images scaled to screen
- document how levels are rendered

## Testing
- `node -e "console.log(Array.isArray(require('./levels.json')) ? 'ok' : 'not ok')"`

------
https://chatgpt.com/codex/tasks/task_e_684a5d29dc4483269d25117ded8ca2a0