### PR TITLE
Implement completion detection and reset button

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,10 +3,12 @@
 A minimal web-based game skeleton that demonstrates how to manage multiple screens on a mobile layout. The game includes:
 
 - **Start Screen** – presented when the page loads. Press **Start** to begin.
-- **Game Screen** – shows the current level. Press **Complete Level** to finish a level.
+- **Game Screen** – shows the current level with a **Reset Level** button.
 - **Level Completed Screen** – displays when a level is completed. Press **Next Level** to continue to the next level.
 
 Each screen fills the entire viewport so there is no scrolling on mobile devices. The JavaScript manages transitions between screens and keeps track of the current level number, starting from 1.
+
+Levels automatically advance once every base contains objects of a single color or is empty.
 
 This project is intended as a simple starting point for expanding into a full puzzle game where players sort colors into the correct order.
 

--- a/index.html
+++ b/index.html
@@ -14,6 +14,7 @@
 
     <div id="game-screen" class="screen">
         <canvas id="game-canvas"></canvas>
+        <button id="reset-button">Reset Level</button>
     </div>
 
     <div id="completed-screen" class="screen">

--- a/script.js
+++ b/script.js
@@ -160,6 +160,37 @@ function drawLevel() {
     bases.forEach(b => b.draw());
 }
 
+/**
+ * Determine whether the level is complete.
+ * A level is complete when every base is either empty or all
+ * objects on that base share the same color.
+ */
+function isLevelCompleted() {
+    return bases.every(b => {
+        if (b.objects.length === 0) return true;
+        return b.objects.every(o => o.name === b.objects[0].name);
+    });
+}
+
+/**
+ * Display the completion screen after verifying the current level
+ * is solved. The next button is hidden when no further levels are
+ * available so the screen simply announces the game is finished.
+ */
+function showCompletionScreen() {
+    const title = document.getElementById('completed-title');
+    const nextBtn = document.getElementById('next-button');
+    const lastLevel = currentLevel === levelConfigs.length;
+    if (lastLevel) {
+        title.textContent = 'Game Complete';
+        nextBtn.style.display = 'none';
+    } else {
+        title.textContent = `Level ${currentLevel} Completed`;
+        nextBtn.style.display = 'inline-block';
+    }
+    showScreen('completed');
+}
+
 
 /**
  * Load level configuration from an external JSON file.
@@ -188,6 +219,14 @@ async function showLevel(number) {
     selectedObjects = [];
     await prepareLevel(level);
     drawLevel();
+}
+
+/**
+ * Reload the current level from the original configuration.
+ * This allows the player to restart the puzzle at any time.
+ */
+function resetLevel() {
+    showLevel(currentLevel);
 }
 
 const screens = {
@@ -266,8 +305,11 @@ function handleCanvasClick(evt) {
         selectedObjects.forEach(o => { o.isSelected = false; });
         selectedBase = null;
         selectedObjects = [];
-    }
+    } 
     drawLevel();
+    if (isLevelCompleted()) {
+        showCompletionScreen();
+    }
 }
 
 document.getElementById('start-button').addEventListener('click', () => {
@@ -277,6 +319,8 @@ document.getElementById('start-button').addEventListener('click', () => {
 });
 
 canvas.addEventListener('click', handleCanvasClick);
+
+document.getElementById('reset-button').addEventListener('click', resetLevel);
 
 
 document.getElementById('next-button').addEventListener('click', () => {

--- a/style.css
+++ b/style.css
@@ -36,3 +36,10 @@ button {
     pointer-events: auto;
 }
 
+#reset-button {
+    position: absolute;
+    bottom: 20px;
+    left: 50%;
+    transform: translateX(-50%);
+}
+


### PR DESCRIPTION
## Summary
- add reset button to the game screen
- detect when each base has one color and show the completed screen
- hide the `Next Level` button when the last level is completed
- allow restarting the current level
- document new behaviour

## Testing
- `node --version`

------
https://chatgpt.com/codex/tasks/task_e_684acfb2dc9883268eecde29083be787