### PR TITLE
Add level-completion overlay

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ A web-based game. The game includes:
 
 - **Start Screen** – presented when the page loads. Press **Start** to begin.
 - **Game Screen** – shows the current level with a **Reset Level** button.
-- **Level Completed Screen** – displays when a level is completed. Press **Next Level** to continue to the next level.
+- **Completion Overlay** – appears on top of the level when it is solved and contains a **Next Level** button.
 
 Each screen fills the entire viewport so there is no scrolling on mobile devices. The JavaScript manages transitions between screens and keeps track of the current level number, starting from 1.
 

--- a/www/index.html
+++ b/www/index.html
@@ -18,12 +18,14 @@
             <button id="reset-button">🔄 Reset Level</button>
             <button id="undo-button" disabled>↩️ Undo</button>
         </div>
+        <div id="completion-overlay">
+            <div id="completion-box">
+                <h1 id="completed-title">Level 1 Completed</h1>
+                <button id="next-button">Next Level</button>
+            </div>
+        </div>
     </div>
 
-    <div id="completed-screen" class="screen">
-        <h1 id="completed-title">Level 1 Completed</h1>
-        <button id="next-button">Next Level</button>
-    </div>
 
     <script src="script.js"></script>
 </body>

--- a/www/script.js
+++ b/www/script.js
@@ -188,11 +188,13 @@ function isLevelCompleted() {
 }
 
 /**
- * Display the completion screen after verifying the current level
- * is solved. The next button is hidden when no further levels are
- * available so the screen simply announces the game is finished.
+ * Display a modal overlay announcing the current level is solved.
+ * The overlay covers the canvas to block further interaction while
+ * still showing the completed layout underneath. The button to
+ * advance is hidden when no more levels are available.
  */
 function showCompletionScreen() {
+    const overlay = document.getElementById('completion-overlay');
     const title = document.getElementById('completed-title');
     const nextBtn = document.getElementById('next-button');
     const lastLevel = currentLevel === levelConfigs.length;
@@ -200,10 +202,10 @@ function showCompletionScreen() {
         title.textContent = 'Game Complete';
         nextBtn.style.display = 'none';
     } else {
-        title.textContent = `Level ${currentLevel} Completed`;
+        title.textContent = `Congratulations!\nLevel ${currentLevel} complete!`;
         nextBtn.style.display = 'inline-block';
     }
-    showScreen('completed');
+    overlay.classList.add('active');
 }
 
 
@@ -248,8 +250,7 @@ function resetLevel() {
 
 const screens = {
     start: document.getElementById('start-screen'),
-    game: document.getElementById('game-screen'),
-    completed: document.getElementById('completed-screen')
+    game: document.getElementById('game-screen')
 };
 const undoButton = document.getElementById('undo-button');
 
@@ -369,6 +370,7 @@ undoButton.addEventListener('click', undoMove);
 document.getElementById('next-button').addEventListener('click', () => {
     currentLevel += 1;
     showLevel(currentLevel);
+    document.getElementById('completion-overlay').classList.remove('active');
     showScreen('game');
 });
 

--- a/www/style.css
+++ b/www/style.css
@@ -50,5 +50,28 @@ button {
     pointer-events: auto;
 }
 
+#completion-overlay {
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    display: none;
+    align-items: center;
+    justify-content: center;
+    background: rgba(0, 0, 0, 0.5);
+    pointer-events: auto;
+}
+
+#completion-overlay.active {
+    display: flex;
+}
+
+#completion-box {
+    background: rgba(0, 0, 0, 0.8);
+    padding: 20px 40px;
+    border-radius: 10px;
+}
+
 
 


### PR DESCRIPTION
## Summary
- overlay completion message on game screen
- style overlay with semi-transparent box
- adjust script logic to show/hide overlay
- document new overlay in README

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_684bec0504248326b3111f377fbd53f7